### PR TITLE
refactor: correct filename generation to use file.filename instead of…

### DIFF
--- a/src/api/routes/fileRoute.ts
+++ b/src/api/routes/fileRoute.ts
@@ -11,7 +11,7 @@ const storage = multer.diskStorage({
     // Get user from res.locals instead of req.body
     const userId = (req as Request).res?.locals.user.user_id;
     const extension = file.originalname.split('.').pop();
-    const newFilename = `${file.fieldname}_${userId}.${extension}`;
+    const newFilename = `${file.filename}_${userId}.${extension}`;
     cb(null, newFilename);
   },
 });

--- a/src/utils/getVideoThumbnail.ts
+++ b/src/utils/getVideoThumbnail.ts
@@ -24,7 +24,7 @@ const getVideoThumbnail = (
           .input(videoUrl)
           .outputOptions([
             '-vf',
-            'fps=10,scale=320:-1:flags=lanczos',
+            'setpts=PTS/(duration/5),fps=5,scale=480:-1:flags=lanczos', // Compress timeline to 5 seconds
             '-c:v',
             'gif',
             '-f',


### PR DESCRIPTION
… file.fieldname and adjust video thumbnail processing for improved frame rate

## Summary by Sourcery

Enhancements:
- Use `file.filename` instead of `file.fieldname` when generating file names.